### PR TITLE
Fetch latest posts from the database

### DIFF
--- a/database/0005-posts.sql
+++ b/database/0005-posts.sql
@@ -1,0 +1,144 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+
+-- migrate:up
+
+--------------------------------------------------------------------------------
+-- Posts
+
+CREATE TABLE posts
+(
+    id         uuid NOT NULL,
+    creator_id uuid NOT NULL,
+
+    PRIMARY KEY (id),
+
+    FOREIGN KEY (creator_id)
+        REFERENCES creators (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_posts_creator_id
+    ON posts (creator_id);
+
+--------------------------------------------------------------------------------
+-- Post visibilities
+
+CREATE TABLE post_visibilities
+(
+    post_id uuid        NOT NULL,
+    created timestamptz NOT NULL,
+    visible boolean     NOT NULL,
+
+    FOREIGN KEY (post_id)
+        REFERENCES posts (id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX ix_post_visibilities_post_id_created
+    ON post_visibilities (post_id, created DESC);
+
+CREATE FUNCTION post_current_visibility(uuid)
+    RETURNS boolean
+    LANGUAGE SQL
+    STABLE
+    RETURNS NULL ON NULL INPUT
+    PARALLEL SAFE
+    AS $$
+        SELECT visible
+        FROM post_visibilities
+        WHERE post_id = $1
+        ORDER BY created DESC
+        LIMIT 1
+    $$;
+
+CREATE FUNCTION post_first_published(uuid)
+    RETURNS timestamptz
+    LANGUAGE SQL
+    STABLE
+    RETURNS NULL ON NULL INPUT
+    PARALLEL SAFE
+    AS $$
+        SELECT created
+        FROM post_visibilities
+        WHERE
+            post_id = $1
+            AND visible
+        ORDER BY created ASC
+        LIMIT 1
+    $$;
+
+--------------------------------------------------------------------------------
+-- Post titles
+
+CREATE TABLE post_titles
+(
+    post_id uuid        NOT NULL,
+    created timestamptz NOT NULL,
+    title   text        NOT NULL,
+
+    FOREIGN KEY (post_id)
+        REFERENCES posts (id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX ix_post_titles_post_id_created
+    ON post_titles (post_id, created DESC);
+
+CREATE FUNCTION post_current_title(uuid)
+    RETURNS text
+    LANGUAGE SQL
+    STABLE
+    RETURNS NULL ON NULL INPUT
+    PARALLEL SAFE
+    AS $$
+        SELECT title
+        FROM post_titles
+        WHERE post_id = $1
+        ORDER BY created DESC
+        LIMIT 1
+    $$;
+
+--------------------------------------------------------------------------------
+-- Post contents
+
+CREATE TABLE post_contents
+(
+    post_id uuid        NOT NULL,
+    created timestamptz NOT NULL,
+    content   text        NOT NULL,
+
+    FOREIGN KEY (post_id)
+        REFERENCES posts (id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX ix_post_contents_post_id_created
+    ON post_contents (post_id, created DESC);
+
+CREATE FUNCTION post_current_content(uuid)
+    RETURNS text
+    LANGUAGE SQL
+    STABLE
+    RETURNS NULL ON NULL INPUT
+    PARALLEL SAFE
+    AS $$
+        SELECT content
+        FROM post_contents
+        WHERE post_id = $1
+        ORDER BY created DESC
+        LIMIT 1
+    $$;
+
+-- migrate:down
+
+DROP FUNCTION post_current_content(uuid);
+DROP TABLE post_contents;
+
+DROP FUNCTION post_current_title(uuid);
+DROP TABLE post_titles;
+
+DROP FUNCTION post_first_published(uuid);
+DROP FUNCTION post_current_visibility(uuid);
+DROP TABLE post_visibilities;
+
+DROP TABLE posts;

--- a/scripts/seed-database.bash
+++ b/scripts/seed-database.bash
@@ -43,21 +43,59 @@ INSERT INTO creator_names
     (creator_id, created, name)
 VALUES
     ( '6fdc4c36-91b6-4946-9b8e-3cdf7ad56588'
-    , now()
+    , '2021-08-28T12:45:00Z'
     , 'Henk de Vries' ),
     ( '584c76d5-d016-4c17-9cd7-bc469cec43f6'
-    , now()
+    , '2021-08-30T15:00:00Z'
     , 'Cooking with Alex' );
 
 INSERT INTO creator_biographies
     (creator_id, created, biography)
 VALUES
     ( '6fdc4c36-91b6-4946-9b8e-3cdf7ad56588'
-    , now()
+    , '2021-08-28T12:45:00Z'
     , 'Hallo, ik ben Henk de Vries!' ),
     ( '584c76d5-d016-4c17-9cd7-bc469cec43f6'
-    , now()
+    , '2021-08-30T15:00:00Z'
     , 'Join me in my kitchen! I post weekly cooking videos.' );
+
+INSERT INTO posts
+    (id, creator_id)
+VALUES
+    ( 'f79fb2c5-42d7-4abd-8dda-acd7761b4f7a'
+    , '6fdc4c36-91b6-4946-9b8e-3cdf7ad56588' ),
+    ( 'aebadd6c-894b-4a46-9448-9702231ee019'
+    , '6fdc4c36-91b6-4946-9b8e-3cdf7ad56588' );
+
+INSERT INTO post_visibilities
+    (post_id, created, visible)
+VALUES
+    ( 'f79fb2c5-42d7-4abd-8dda-acd7761b4f7a'
+    , '2021-08-30T15:45:00Z'
+    , TRUE ),
+    ( 'aebadd6c-894b-4a46-9448-9702231ee019'
+    , '2021-09-01T12:15:00Z'
+    , TRUE );
+
+INSERT INTO post_titles
+    (post_id, created, title)
+VALUES
+    ( 'f79fb2c5-42d7-4abd-8dda-acd7761b4f7a'
+    , '2021-08-30T15:45:00Z'
+    , 'Haskell Podcast #1' ),
+    ( 'aebadd6c-894b-4a46-9448-9702231ee019'
+    , '2021-09-01T12:15:00Z'
+    , 'Haskell Podcast #2' );
+
+INSERT INTO post_contents
+    (post_id, created, content)
+VALUES
+    ( 'f79fb2c5-42d7-4abd-8dda-acd7761b4f7a'
+    , '2021-08-30T15:45:00Z'
+    , 'In this episode we will take a look at recursion schemes.' ),
+    ( 'aebadd6c-894b-4a46-9448-9702231ee019'
+    , '2021-09-01T12:15:00Z'
+    , 'In this episode we will take a look at GADTs.' );
 
 COMMIT WORK;
 


### PR DESCRIPTION
#13.

This change adds tables for information about posts. It also replaces the hard coded example posts with a SQL query.

No schema is included for post attachments. We should first think about how attachments should work, and introduce them in a separate PR.

The query still queries the posts through the nickname. We can query them by creator identifier directly, by having `fetchCreatorPosts` take `CreatorId` instead of `Nickname`, after #21.
