### PR TITLE
Identify creators by id internally, not by nickname

### DIFF
--- a/adatipd/adatipd.cabal
+++ b/adatipd/adatipd.cabal
@@ -35,6 +35,7 @@ library
 
     exposed-modules:
         Adatipd.Cardano
+        Adatipd.Creator
         Adatipd.Nickname
         Adatipd.Options
         Adatipd.Sql
@@ -55,6 +56,7 @@ library
         hasql,
         http-types,
         optparse-applicative,
+        postgresql-binary,
         qrcode-core,
         qrcode-juicypixels,
         scientific,

--- a/adatipd/src/Adatipd/Creator.hs
+++ b/adatipd/src/Adatipd/Creator.hs
@@ -1,0 +1,96 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Adatipd.Creator
+  ( CreatorId (..)
+  , CreatorInfo (..)
+  , fetchCreatorIdAndCurrentNickname
+  , encodeCreatorId
+  , fetchCreatorInfo
+  ) where
+
+import Adatipd.Nickname (Nickname)
+import Data.Functor.Contravariant ((>$<))
+import Data.Text (Text)
+import PostgreSQL.Binary.Data (UUID)
+
+import qualified Adatipd.Nickname as Nickname
+import qualified Adatipd.Sql as Sql
+import qualified Hasql.Decoders as SqlDec
+import qualified Hasql.Encoders as SqlEnc
+
+newtype CreatorId = CreatorId { getCreatorId :: UUID }
+
+encodeCreatorId :: SqlEnc.Params CreatorId
+encodeCreatorId =
+  SqlEnc.param (SqlEnc.nonNullable (getCreatorId >$< SqlEnc.uuid))
+
+decodeNickname :: CreatorId -> SqlDec.Row Nickname
+decodeNickname (CreatorId creatorId) = do
+  nicknameRaw <- SqlDec.column (SqlDec.nonNullable SqlDec.text)
+  case Nickname.parse nicknameRaw of
+    Right nickname -> pure nickname
+    Left err -> fail $
+      "Invalid nickname for creator " <> show creatorId <> ": " <> err
+
+-- | Given any nickname for the creator, return their id and current nickname.
+fetchCreatorIdAndCurrentNickname
+  :: Sql.Connection
+  -> Nickname
+  -> IO (Maybe (CreatorId, Nickname))
+fetchCreatorIdAndCurrentNickname sqlConn nickname =
+  let
+    encodeNickname :: SqlEnc.Params Nickname
+    encodeNickname =
+      SqlEnc.param (SqlEnc.nonNullable (Nickname.format >$< SqlEnc.text))
+
+    decode :: SqlDec.Row (CreatorId, Nickname)
+    decode = do
+      creatorId       <- CreatorId <$> SqlDec.column (SqlDec.nonNullable SqlDec.uuid)
+      currentNickname <- decodeNickname creatorId
+      pure (creatorId, currentNickname)
+
+  in
+    Sql.runSession sqlConn $ Sql.statement nickname $
+      Sql.Statement
+        "SELECT\n\
+        \  creator_id, \n\
+        \  creator_current_nickname(creator_id)\n\
+        \FROM\n\
+        \  creator_nicknames\n\
+        \WHERE\n\
+        \  nickname = $1"
+        encodeNickname
+        (SqlDec.rowMaybe decode)
+        False
+
+data CreatorInfo =
+  CreatorInfo
+    { ciNickname :: Nickname
+    , ciName :: Text
+    , ciBiography :: Text
+    }
+
+fetchCreatorInfo :: Sql.Connection -> CreatorId -> IO CreatorInfo
+fetchCreatorInfo sqlConn creatorId =
+
+  Sql.runSession sqlConn $
+    Sql.statement creatorId $
+      Sql.Statement
+        "SELECT\n\
+        \  creator_current_nickname($1),\n\
+        \  creator_current_name($1),\n\
+        \  creator_current_biography($1)"
+        encodeCreatorId
+        (SqlDec.singleRow decodeCreatorInfo)
+        False
+
+  where
+
+    decodeCreatorInfo :: SqlDec.Row CreatorInfo
+    decodeCreatorInfo = do
+      ciNickname  <- decodeNickname creatorId
+      ciName      <- SqlDec.column (SqlDec.nonNullable SqlDec.text)
+      ciBiography <- SqlDec.column (SqlDec.nonNullable SqlDec.text)
+      pure CreatorInfo {..}

--- a/adatipd/src/Adatipd/WaiUtil.hs
+++ b/adatipd/src/Adatipd/WaiUtil.hs
@@ -5,14 +5,20 @@
 module Adatipd.WaiUtil
   ( module Network.Wai
   , responseHtml
+  , responseRedirectPermanently
   ) where
 
 import Network.Wai
 
+import Data.Text (Text)
 import Network.HTTP.Types.Header (ResponseHeaders)
 import Network.HTTP.Types.Status (Status)
 import Text.Blaze (Markup)
 import Text.Blaze.Renderer.Utf8 (renderMarkupBuilder)
+
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Network.HTTP.Types.Status as Status
 
 -- |
 -- Create a response with an HTML body and a media type of @text/html@.
@@ -24,3 +30,14 @@ responseHtml status headers html =
     html' = renderMarkupBuilder html
   in
     responseBuilder status headers' html'
+
+-- |
+-- Respond with 301 Moved Permanently to the given path, provided as segments,
+-- inverse to Wai.pathInfo.
+responseRedirectPermanently :: [Text] -> Response
+responseRedirectPermanently pathInfo =
+  let
+    headers =
+      [ ("Location", Text.encodeUtf8 $ "/" <> Text.intercalate "/" pathInfo) ]
+  in
+    responseLBS Status.movedPermanently301 headers ""

--- a/adatipd/src/Adatipd/Web.hs
+++ b/adatipd/src/Adatipd/Web.hs
@@ -11,10 +11,12 @@ import Adatipd.Web.CreatorPosts (handleCreatorPosts)
 import Adatipd.Web.CreatorTiers (handleCreatorTiers)
 import Adatipd.Web.CreatorTipSuggestions (handleCreatorTipSuggestions)
 import Adatipd.Web.NotFound (handleNotFound)
+import Adatipd.Nickname (Nickname)
 
-import qualified Adatipd.Nickname as Nickname (parseUriComponent)
+import qualified Adatipd.Creator as Creator
+import qualified Adatipd.Nickname as Nickname
 import qualified Adatipd.Sql as Sql
-import qualified Network.Wai as Wai (Application, pathInfo)
+import qualified Adatipd.WaiUtil as Wai
 
 -- |
 -- Handle an incoming HTTP request and write the HTTP response.
@@ -28,14 +30,39 @@ handle options sqlConn request writeResponse =
     -- View patterns can be used to parse path components,
     -- such as in the examples below.
 
-    [Nickname.parseUriComponent -> Right nickname] ->
-      handleCreatorPosts options sqlConn nickname request writeResponse
-
-    [Nickname.parseUriComponent -> Right nickname, "tips"] ->
-      handleCreatorTipSuggestions options sqlConn nickname request writeResponse
-
-    [Nickname.parseUriComponent -> Right nickname, "tiers"] ->
-      handleCreatorTiers options sqlConn nickname request writeResponse
+    (Nickname.parseUriComponent -> Right nickname) : _ ->
+      handleCreator options sqlConn nickname request writeResponse
 
     _ ->
       handleNotFound options request writeResponse
+
+
+-- | Handle any page behind the /~creatorid path.
+handleCreator :: Options -> Sql.Connection -> Nickname -> Wai.Application
+handleCreator options sqlConn nickname request writeResponse =
+  Creator.fetchCreatorIdAndCurrentNickname sqlConn nickname >>= \case
+    Nothing ->
+      -- If no creator with this nickname exists, serve the generic not found
+      -- page.
+      handleNotFound options request writeResponse
+
+    Just (_creatorId, currentNickname) | nickname /= currentNickname ->
+      -- If the creator exists, but there is a newer nickname, redirect to the
+      -- same url but with the new nickname. This loses the query string.
+      writeResponse
+        $ Wai.responseRedirectPermanently
+        $ Nickname.formatUriComponent currentNickname
+        : tail (Wai.pathInfo request)
+
+    Just (creatorId, _) -> case tail (Wai.pathInfo request) of
+      [] ->
+        handleCreatorPosts options sqlConn creatorId request writeResponse
+
+      ["tips"] ->
+        handleCreatorTipSuggestions options sqlConn creatorId request writeResponse
+
+      ["tiers"] ->
+        handleCreatorTiers options sqlConn creatorId request writeResponse
+
+      _ ->
+        handleNotFound options request writeResponse


### PR DESCRIPTION
This turned out to be a more invasive refactor than I expected, but I
think it simplifies things in the end.

 * Add a new module for the Creator-related things, in particular the
   creator id.

 * Accept CreatorId instead of Nickname in the page renderers.

 * In the router, look up the creator id and current nickname, from the
   nickname in the url. If the nickname in the url is outdated, serve a
   redirect. If it is still up to date, then now we have a creator id
   that we can use for the remaining routes.

 * Assume that queries which take a creator id never fail to look up the
   creator with that id. We resolve the nickname to an id once at the
   start, and this can fail, and then afterwards we can just assume that
   the creator is there. This simplifies many things because we don't
   have to match and serve the "not found" page all the time.