### PR TITLE
Simplify tip suggestions page

### DIFF
--- a/adatipd/src/Adatipd/Web/CreatorTipSuggestions.hs
+++ b/adatipd/src/Adatipd/Web/CreatorTipSuggestions.hs
@@ -108,7 +108,7 @@ renderCreatorTipSuggestions options CreatorTipSuggestions {..} =
       renderTutorial ctsCreatorInfo
       renderTipSuggestions ctsTipSuggestions ctsCustomAmountQrImage
       renderTipAddress ctsCreatorInfo ctsTipAddress
-      renderFinePrint options
+      renderFinePrint ctsCreatorInfo options
 
 renderTutorial :: CreatorInfo -> Markup
 renderTutorial CreatorInfo {..} =
@@ -171,9 +171,23 @@ renderTipAddress CreatorInfo {..} tipAddress =
     HB.text ciName *> ": "
     HH.code $ HB.text (formatBech32 tipAddress)
 
-renderFinePrint :: Options -> Markup
-renderFinePrint Options {..} =
+renderFinePrint :: CreatorInfo -> Options -> Markup
+renderFinePrint CreatorInfo {..} Options {..} =
   HH.p ! HA.class_ "-fine-print" $ do
-    "Tips do not grant access to exclusive content." *> HH.br
-    "Do not send coins other than Ada to the address." *> HH.br
-    HH.text oInstanceTitle *> " will not charge you for sending tips."
+    "When you send a tip, you send Ada directly to "
+    HB.text ciName *> ". "
+
+    HB.text ciName *> " will receive the full tipped amount: "
+    HH.text oInstanceTitle *> " does not process the tip and "
+    "does not charge you for sending tips. "
+
+    "Tips are voluntary and do not grant access to exclusive content "
+    "on " *> HB.text oInstanceTitle *> ". "
+
+    "The Cardano network may additionally charge a transaction fee. "
+    "Your wallet will show you the fee before you sign the transaction. "
+
+    "Only send Cardano assets, such as Ada, to the address. "
+    "Do not send assets of other cryptocurrency platforms "
+    "such as Bitcoin or Ethereum to the address; "
+    "they will not arrive and they will be lost unrecoverably."

--- a/adatipd/src/Adatipd/Web/CreatorTipSuggestions.hs
+++ b/adatipd/src/Adatipd/Web/CreatorTipSuggestions.hs
@@ -153,7 +153,7 @@ renderTipSuggestion i TipSuggestion {..} = do
         "Unfortunately no QR code could \
         \be generated for this address."
     Just qrImage -> do
-      let qrImagePng = Qr.toPngDataUrlT 4 8 qrImage
+      let qrImagePng = Qr.toPngDataUrlT 0 8 qrImage
       HH.img
         ! HA.class_ "-qr-code"
         ! HA.src (HB.lazyTextValue qrImagePng)

--- a/adatipd/static/creator-tip-suggestions.scss
+++ b/adatipd/static/creator-tip-suggestions.scss
@@ -40,6 +40,13 @@
         padding-top: calc(#{size(0.5em)} - 1px);
     }
 
+    & > .-fine-print
+    {
+        color: var(--fine-print-color);
+        font-size: 0.8em;
+        line-height: size(1rem);
+    }
+
     & > .-tip-address > code
     {
         display: block;

--- a/adatipd/static/creator-tip-suggestions.scss
+++ b/adatipd/static/creator-tip-suggestions.scss
@@ -18,11 +18,12 @@
     & > .-tutorial,
     & > .-tip-suggestions,
     & > .-tip-address,
-    & > .-fine-print
+    & > .-fine-print,
+    & > .-tip-suggestions > .-qr-code
     {
-        // The QR code takes up about half the space.
-        // Make sure not to render text behind it.
-        width: 50%;
+        // Divide the page into two columns 50/50.
+        // Text and buttons left, QR code right.
+        width: calc(50% - #{size(1rem) / 2});
     }
 
     & > .-tutorial,

--- a/adatipd/static/creator-tip-suggestions.scss
+++ b/adatipd/static/creator-tip-suggestions.scss
@@ -93,6 +93,13 @@
             right: 0;
 
             // Use nearest neighbor scaling for QR codes.
+            // There are two similar options: crisp-edges and pixelated.
+            // Mozilla Developer Network says:
+            // > Although crisp-edges is supposed to use a pixel-art scaler
+            // > like in the specification example, in practice no browsers
+            // > (as of January 2020) does so.
+            // > In Firefox, crisp-edges is interpreted as nearest-neighbor,
+            // > pixelated is not supported.
             image-rendering: crisp-edges;
         }
 

--- a/adatipd/static/creator-tip-suggestions.scss
+++ b/adatipd/static/creator-tip-suggestions.scss
@@ -7,80 +7,97 @@
     @include center-content;
     @include creator-tabs-content-margin;
 
-    display: flex;
-    gap: size(1rem);
-    flex-wrap: wrap;
-    justify-content: center;
+    // We use absolute positioning for the QR code.
+    // By configuring the parent to use relative positioning,
+    // the QR code will be positioned within the parent
+    // rather than absolutely within the page.
+    position: relative;
 
     margin-bottom: size(1rem);
 
-    & > .-tutorial
+    & > .-tutorial,
+    & > .-tip-suggestions,
+    & > .-tip-address,
+    & > .-fine-print
     {
-        @include rich-text;
-        text-align: center;
-        width: $page-width;
+        // The QR code takes up about half the space.
+        // Make sure not to render text behind it.
+        width: 50%;
     }
 
-    & > article
+    & > .-tutorial,
+    & > .-tip-address,
+    & > .-fine-print
     {
-        border: dashed 3px var(--subtle-highlight-color);
-        border-radius: size(1rem);
+        @include rich-text;
+    }
 
-        text-align: center;
+    & > .-tip-address,
+    & > .-fine-print
+    {
+        border-top: dashed 1px var(--subtle-highlight-color);
+        margin-top: size(0.5em);
+        padding-top: calc(#{size(0.5em)} - 1px);
+    }
 
-        // The QR code adds padding of its own, as it has a white border.
-        // So we do not need to set left and right padding for the article.
-        padding: size(1rem) 0;
+    & > .-tip-address > code
+    {
+        display: block;
+        word-break: break-all;
+    }
 
-        &:hover
+    & > .-tip-suggestions
+    {
+        // This allows us to nicely flow the amount buttons
+        // and to put a consistent amount of whitespace between them.
+        display: flex;
+        flex-wrap: wrap;
+        gap: size(0.25rem);
+
+        padding: size(0.5rem) 0;
+
+        & > .-label
         {
-            border-color: var(--primary-color);
-            border-style: solid;
-        }
+            background: var(--primary-color);
+            border-radius: size(0.5em);
+            color: white;
 
-        // QR codes are annoying to look at, so dim them if unnoticed.
-        // Also dim the addresses as it looks nicer that way.
-        &:not(:hover) > .-qr-code,
-        &:not(:hover) > .-address
-        {
-            opacity: 0.1;
-        }
+            cursor: pointer;
 
-        & > .-header
-        {
-            font-size: 2rem;
+            padding: 0 size(0.5em);
+
             font-weight: bold;
             line-height: size(1em);
 
-            & > .-title,
-            & > .-amount
-            {
-                display: inline;
-            }
-
-            & > .-amount
-            {
-                background: var(--primary-color);
-                border-radius: size(1em);
-                color: white;
-                margin-left: size(0.5rem);
-                padding: 0 size(0.25em);
-            }
+            display: inline-block;
         }
 
         & > .-qr-code
         {
+            // Hide the QR code until the associated radio button is checked.
+            // This is restored in the ‘.-radio:checked + .-label + .-qr-code’
+            // selector elsewhere in this style sheet.
+            display: none;
+
+            // Put the QR code next to the amount selection.
+            position: absolute;
+            top: 0;
+            right: 0;
+
             // Use nearest neighbor scaling for QR codes.
             image-rendering: crisp-edges;
         }
 
-        & > .-address
+        & > .-radio
         {
-            font-family: monospace;
-            word-break: break-all;
+            display: none;
 
-            margin: 0 auto;
-            width: $page-width / 3;
+            // When checked, highlight the label and display the QR code.
+            &:checked
+            {
+                & + .-label { background: var(--secondary-color); }
+                & + .-label + .-qr-code { display: inline; }
+            }
         }
     }
 }

--- a/adatipd/static/stylesheet.scss
+++ b/adatipd/static/stylesheet.scss
@@ -51,6 +51,11 @@ $page-width: 960px;
 {
     line-height: size(1em);
 
+    & code
+    {
+        font-family: monospace;
+    }
+
     & strong
     {
         font-weight: bold;

--- a/adatipd/static/stylesheet.scss
+++ b/adatipd/static/stylesheet.scss
@@ -74,6 +74,7 @@ body
     --primary-color: #001AA5;
     --secondary-color: orange;
     --subtle-highlight-color: #EEEEEE;
+    --fine-print-color: gray;
 
     // This may be overridden by the page using a style attribute.
     --creator-banner-image: url("/static/default-creator-banner-image.jpg");


### PR DESCRIPTION
 · Only one QR code is displayed at a time.
 · Tip suggestion titles are gone.
 · Configured tip suggestions now always have an amount.
   And there is always a single “custom amount” option.
 · Add warning about sending other coins.