### PR TITLE
Run tests in parallel

### DIFF
--- a/adatipd/adatipd.cabal
+++ b/adatipd/adatipd.cabal
@@ -11,6 +11,7 @@ common haskell-settings
     default-extensions:
         DeriveAnyClass
         DerivingStrategies
+        GeneralizedNewtypeDeriving
         LambdaCase
         NamedFieldPuns
         NumericUnderscores
@@ -24,6 +25,9 @@ common haskell-settings
         -Wall
         -Wincomplete-record-updates
         -Wincomplete-uni-patterns
+        -threaded
+        -rtsopts
+        -with-rtsopts=-N
 
 library
 
@@ -102,21 +106,24 @@ test-suite test-unit
         test-unit
 
     main-is:
-        Spec.hs
+        Main.hs
 
     other-modules:
         Adatipd.CardanoSpec
+        Adatipd.E2ETest
         Adatipd.NicknameSpec
-        Adatipd.Sql.Test
+        Adatipd.SqlTest
         Adatipd.WebSpec
+        Spec
 
     build-depends:
         adatipd,
         aeson,
         base,
         bytestring,
-        hasql,
+        directory,
         hedgehog,
+        http-types,
         hspec,
         hspec-discover,
         hspec-expectations,
@@ -124,4 +131,6 @@ test-suite test-unit
         process,
         temporary,
         text,
-        time
+        time,
+        transformers,
+        wai

--- a/adatipd/src/Adatipd/Options.hs
+++ b/adatipd/src/Adatipd/Options.hs
@@ -14,8 +14,7 @@ import Data.Text (Text)
 
 data Options =
   Options
-    { oCardanoNodeSocketPath :: FilePath
-    , oEnableSignUp :: Bool
+    { oEnableSignUp :: Bool
     , oInstanceTitle :: Text }
   deriving stock (Show)
 
@@ -27,14 +26,6 @@ optionsParserInfo =
 
 optionsParser :: Parser Options
 optionsParser = do
-
-  oCardanoNodeSocketPath <-
-    strOption $
-      long "cardano-node-socket-path"
-      <> metavar "PATH"
-      <> help "The same path given to cardano-node \
-              \as the --socket-path argument. \
-              \Used for talking to cardano-node."
 
   oEnableSignUp <-
     switch $

--- a/adatipd/test-unit/Adatipd/E2ETest.hs
+++ b/adatipd/test-unit/Adatipd/E2ETest.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- This module aids in writing end-to-end tests.
+-- Within the 'E2E' monad, you can send requests to the request handler.
+-- The response will be returned, which you can then inspect.
+module Adatipd.E2ETest
+  ( E2E
+  , runE2E
+  , runE2E'
+  , testOptions
+  , sendRequest
+  , sendRequest'
+  ) where
+
+import Adatipd.Options (Options (..))
+import Adatipd.SqlTest (withSqlConnection)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Reader (ReaderT, runReaderT)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Text (Text)
+import Network.HTTP.Types.Method (Method)
+
+import qualified Adatipd.Sql as Sql (Connection)
+import qualified Adatipd.WaiUtil as Wai
+import qualified Adatipd.Web as Web (handle)
+import qualified Control.Monad.Trans.Reader as Reader (asks)
+import qualified Network.Wai.Internal as Wai (ResponseReceived (..))
+
+newtype E2E a =
+  E2E (ReaderT Env IO a)
+  deriving newtype (Functor, Applicative, Monad)
+
+data Env =
+  Env
+    { eOptions :: Options
+    , eSqlConn :: Sql.Connection }
+
+-- |
+-- Run an end-to-end test within a configurable environment.
+-- This function will use 'testOptions' for the options,
+-- but those can be adjusted by passing a custom function.
+-- This function will spin up a test database for use by the test,
+-- so you do not need to do that yourself within the test.
+runE2E :: (Options -> Options) -> E2E a -> IO a
+runE2E changeOptions action =
+  withSqlConnection $
+    \sqlConn ->
+      let options = changeOptions testOptions in
+      runE2E' options sqlConn action
+
+-- |
+-- Lower-level version of 'runE2E' that gives the caller
+-- more control over the environment.
+runE2E' :: Options -> Sql.Connection -> E2E a -> IO a
+runE2E' eOptions eSqlConn (E2E action) =
+  runReaderT action Env {..}
+
+-- |
+-- Reasonable options for end-to-end tests.
+testOptions :: Options
+testOptions =
+  let
+    oEnableSignUp = True
+    oInstanceTitle = "adatip.test"
+  in
+    Options {..}
+
+-- |
+-- Send a request to the request handler and return the response.
+sendRequest :: Method -> [Text] -> E2E Wai.Response
+sendRequest requestMethod pathInfo =
+  sendRequest' $
+    Wai.defaultRequest
+      { Wai.requestMethod = requestMethod
+      , Wai.pathInfo = pathInfo }
+
+-- |
+-- Lower-level version of 'sendRequest'.
+sendRequest' :: Wai.Request -> E2E Wai.Response
+sendRequest' request = E2E $ do
+  options <- Reader.asks eOptions
+  sqlConn <- Reader.asks eSqlConn
+  liftIO $ do
+    response <- newIORef Nothing
+    let writeResponse response' = do
+          writeIORef response (Just response')
+          pure Wai.ResponseReceived
+    Wai.ResponseReceived <-
+      Web.handle options sqlConn request writeResponse
+    readIORef response >>= \case
+      Nothing -> fail "Request handler neglected writing a response"
+      Just response' -> pure response'

--- a/adatipd/test-unit/Adatipd/NicknameSpec.hs
+++ b/adatipd/test-unit/Adatipd/NicknameSpec.hs
@@ -9,7 +9,7 @@ module Adatipd.NicknameSpec
 import Adatipd.Nickname (format, parse)
 import Control.Applicative ((<|>))
 import Data.Function ((&))
-import Test.Hspec (Spec, it, shouldBe)
+import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.Hspec.Hedgehog ((===), hedgehog)
 
 import qualified Data.Char as Char (isAsciiLower, isAsciiUpper, isDigit)
@@ -30,27 +30,29 @@ invalidChars = HG.filter (not . isValid) HG.unicode
                     Char.isDigit c
 
 spec :: Spec
-spec = do
+spec =
 
-  it "parse accepts valid input" $
-    hedgehog $ do
-      let lengthRange = HR.linear minLength maxLength
-      input <- H.forAll $ HG.text lengthRange validChars
-      let actual = parse input & fmap format
-      let expected = Right (Text.toLower input)
-      actual === expected
+  describe "parse" $ do
 
-  it "parse rejects empty input" $
-    parse "" `shouldBe` Left "Nickname is empty"
+    it "accepts valid input" $
+      hedgehog $ do
+        let lengthRange = HR.linear minLength maxLength
+        input <- H.forAll $ HG.text lengthRange validChars
+        let actual = parse input & fmap format
+        let expected = Right (Text.toLower input)
+        actual === expected
 
-  it "parse rejects overly long input" $
-    hedgehog $ do
-      let lengthRange = HR.linear (maxLength + 1) (maxLength * 2)
-      input <- H.forAll $ HG.text lengthRange validChars
-      parse input === Left "Nickname is too long"
+    it "rejects empty input" $
+      parse "" `shouldBe` Left "Nickname is empty"
 
-  it "parse rejects input with invalid characters" $
-    hedgehog $ do
-      let lengthRange = HR.linear minLength maxLength
-      input <- H.forAll $ HG.text lengthRange invalidChars
-      parse input === Left "Nickname contains invalid characters"
+    it "rejects overly long input" $
+      hedgehog $ do
+        let lengthRange = HR.linear (maxLength + 1) (maxLength * 2)
+        input <- H.forAll $ HG.text lengthRange validChars
+        parse input === Left "Nickname is too long"
+
+    it "rejects input with invalid characters" $
+      hedgehog $ do
+        let lengthRange = HR.linear minLength maxLength
+        input <- H.forAll $ HG.text lengthRange invalidChars
+        parse input === Left "Nickname contains invalid characters"

--- a/adatipd/test-unit/Adatipd/WebSpec.hs
+++ b/adatipd/test-unit/Adatipd/WebSpec.hs
@@ -6,26 +6,38 @@ module Adatipd.WebSpec
   ( spec
   ) where
 
-import Adatipd.Sql.Test (withSqlConnection)
-import Test.Hspec (Spec, it, shouldBe)
+import Adatipd.E2ETest (runE2E, sendRequest)
+import Data.Foldable (for_)
+import Data.Text.Encoding (encodeUtf8)
+import Test.Hspec (Spec, describe, it, shouldBe)
 
-import qualified Adatipd.Sql as Sql
-import qualified Hasql.Decoders as SqlDec
-import qualified Hasql.Encoders as SqlEnc
+import qualified Adatipd.WaiUtil as Wai
+import qualified Data.Text as Text (unpack)
+import qualified Network.HTTP.Types.Status as Status
 
 spec :: Spec
-spec = do
+spec =
+  describe "handle" $
+    describe "/~creator" creatorSpec
 
-  it "handle redirects to the latest nickname" $
-    withSqlConnection $
-      \sqlConn -> do
-        -- TODO: Replace this with a test that checks nickname redirects.
-        result <-
-          Sql.runSession sqlConn $
-            Sql.statement () $
-              Sql.Statement
-                "SELECT 42"
-                SqlEnc.noParams
-                (SqlDec.singleRow (SqlDec.column (SqlDec.nonNullable SqlDec.int8)))
-                False
-        result `shouldBe` 42
+creatorSpec :: Spec
+creatorSpec =
+  for_ [[], ["tips"], ["tiers"]] $ \page ->
+    describe (foldMap (("/" <>) . Text.unpack) page) $ do
+
+      it "redirects if an old nickname is given" $ do
+        response <- runE2E id $ sendRequest "GET" ("~ingriddevries" : page)
+        Wai.responseStatus response `shouldBe` Status.movedPermanently301
+        let location = lookup "Location" (Wai.responseHeaders response)
+        let expectedLocation = foldMap ("/" <>) ("~henkdevries" : page)
+        location `shouldBe` Just (encodeUtf8 expectedLocation)
+
+      it "does not redirect if the latest nickname is given" $ do
+        response <- runE2E id $ sendRequest "GET" ("~henkdevries" : page)
+        Wai.responseStatus response `shouldBe` Status.ok200
+        let location = lookup "Location" (Wai.responseHeaders response)
+        location `shouldBe` Nothing
+
+      it "returns not found if a non-existing nickname is given" $ do
+        response <- runE2E id $ sendRequest "GET" ("~steve" : page)
+        Wai.responseStatus response `shouldBe` Status.notFound404

--- a/adatipd/test-unit/Main.hs
+++ b/adatipd/test-unit/Main.hs
@@ -1,0 +1,14 @@
+module Main
+  ( main
+  ) where
+
+import Test.Hspec (parallel)
+import Test.Hspec.Runner (defaultConfig, hspecWith)
+
+import qualified Spec (spec)
+
+main :: IO ()
+main =
+  hspecWith defaultConfig $
+    -- We can run all tests in parallel.
+    parallel Spec.spec

--- a/adatipd/test-unit/Spec.hs
+++ b/adatipd/test-unit/Spec.hs
@@ -2,4 +2,4 @@
 
 -- hspec-discover [1] automatically finds test modules.
 -- [1]: https://hspec.github.io/hspec-discover.html
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/scripts/pg_hba.conf
+++ b/scripts/pg_hba.conf
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# This file specifies PostgreSQL authentication per host and role.
+# This file specifies PostgreSQL authentication per database and role.
 # We use password authentication in the development environment,
 # because it is the easiest to set up.
 
-#    database user         address      auth-method
-host all      postgres     127.0.0.1/32 md5
-host adatip   adatip_app   127.0.0.1/32 md5
-host adatip   adatip_setup 127.0.0.1/32 md5
+#     database user         auth-method
+local all      postgres     md5
+local adatip   adatip_app   md5
+local adatip   adatip_setup md5

--- a/scripts/postgresql.conf
+++ b/scripts/postgresql.conf
@@ -4,7 +4,6 @@
 hba_file='scripts/pg_hba.conf'
 ident_file='scripts/pg_ident.conf'
 
-# We use TCP rather than Unix sockets
-# for the development environment.
-unix_socket_directories=''
-listen_addresses='127.0.0.1'
+# We connect to PostgreSQL over a Unix socket.
+# This option disables TCP sockets.
+listen_addresses=''

--- a/scripts/run-adatipd.bash
+++ b/scripts/run-adatipd.bash
@@ -19,5 +19,4 @@ export PGPASSWORD=$PGUSER
 find -type f -name '*.cabal' -or -name '*.hs' |   \
     exec entr -nr -- cabal --offline new-run --   \
         adatipd                                   \
-        --cardano-node-socket-path cardano.socket \
         --instance-title adatip.social

--- a/scripts/run-postgres.bash
+++ b/scripts/run-postgres.bash
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# This script is used by Hivemind
-# and is also used by the tests.
+# This script is used by Hivemind and is also used by the tests.
+# We place a directory for Unix sockets next to the data directory.
+# By using Unix sockets instead of TCP sockets
+# we can easily spin up multiple instances
+# without having to find unique port numbers.
 
 set -efuo pipefail
 
@@ -21,4 +24,6 @@ if ! [[ -e "$PGDATA" ]]; then
 
 fi
 
-exec postgres -c config_file=scripts/postgresql.conf
+socket_dir=$PGDATA/../pgsocket
+
+exec postgres -c config_file=scripts/postgresql.conf -k "$socket_dir"

--- a/shell.nix
+++ b/shell.nix
@@ -57,14 +57,14 @@ let
             # Note that the database setup scripts will override these
             # with their own values as they need to authenticate differently.
             PGDATA = toString state/postgresql/pgdata;
-            PGHOST = "127.0.0.1";
-            PGPORT = "8082";
+            PGHOST = toString state/postgresql/pgsocket;
+            PGPORT = "5432";
             PGUSER = "adatip_setup";
             PGPASSWORD = PGUSER;
             PGDATABASE = "adatip";
 
             # Configure dbmate for the same reason.
-            DATABASE_URL = "postgres://${PGHOST}:${PGPORT}/?sslmode=disable";
+            DATABASE_URL = "postgres:///?socket=${PGHOST}";
             DBMATE_MIGRATIONS_DIR = toString ./database;
             DBMATE_NO_DUMP_SCHEMA = "true";
 

--- a/state/postgresql/.gitignore
+++ b/state/postgresql/.gitignore
@@ -1,2 +1,3 @@
 /*
 !/.gitignore
+!/pgsocket


### PR DESCRIPTION
This adds the following changes:

 - Reorganizes existing tests using ‘describe’.
 - Run all tests in parallel with Hspec parallel.
 - Connect to PostgreSQL over a Unix socket (fixes #42).
 - Add a few tests that use the database.